### PR TITLE
Change default hostname

### DIFF
--- a/package/fa_adept_client.tcl
+++ b/package/fa_adept_client.tcl
@@ -15,7 +15,7 @@ namespace eval ::fa_adept {
 ::itcl::class AdeptClient {
     public variable sock
     public variable host
-    public variable hosts [list eyes.flightaware.com 70.42.6.203]
+    public variable hosts [list piaware.flightaware.com 70.42.6.203]
     public variable port 1200
     public variable connectRetryIntervalSeconds 60
     public variable connected 0


### PR DESCRIPTION
Cherry-picked ab89931ffdb9f173bd201744d9f34b18381566c6 from upstream.

adept client default host is now piaware.flightaware.com

The intention is for anyone using this fork to have a functional default while we wait for the 2.1 merge.
